### PR TITLE
CI/CD with Drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,27 @@
+kind: pipeline
+type: docker
+name: default
+
+steps:
+  - name: deploy stage
+    image: appleboy/drone-ssh:1.6.4
+    settings:
+      host:
+        from_secret: stage_ssh_host
+      username:
+        from_secret: stage_ssh_user
+      password:
+        from_secret: stage_ssh_password
+      port: 22
+      command_timeout: 3m
+      script:
+        - docker pull ghcr.io/alexmyt/purpleschool-nestjs:develop
+        - docker compose up --force-recreate -d node
+        - docker image prune -f
+
+trigger:
+  branch:
+    - develop
+    - ci
+  event:
+    - push

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,18 @@ services:
     ports:
       - "27017:27017"
     volumes:
-      - ./mongo-data:/data/db
+      - mongo-data:/data/db
     command: --wiredTigerCacheSizeGB 1.5
 
+  redis:
+    image: redis:7.0.11-alpine
+    restart: always
+    ports:
+      - '6379:6379'
+    command: redis-server --loglevel warning
+    volumes:
+      - redis-data:/data
     
+volumes:
+  mongo-data:
+  redis-data:

--- a/src/lib/pino.module.ts
+++ b/src/lib/pino.module.ts
@@ -12,27 +12,56 @@ const basePinoOptions = {
 @Module({
   imports: [
     LoggerModule.forRootAsync({
-      useFactory: () => ({
-        pinoHttp: {
-          timestamp: () => `,"timestamp":"${new Date(Date.now()).toISOString()}"`,
-          redact: {
-            paths: redactFields,
-            censor: '**GDPR COMPLIANT**',
-          },
-          transport: {
-            targets: [
-              {
-                target: 'pino-pretty',
-                level: 'info', // log only info and above to console
-                options: {
-                  ...basePinoOptions,
-                  colorize: true,
+      useFactory: () => {
+        const isProdEnv = process.env.NODE_ENV && process.env.NODE_ENV.startsWith('prod');
+        const isTestEnv = process.env.NODE_ENV && process.env.NODE_ENV.startsWith('test');
+
+        return {
+          pinoHttp: {
+            timestamp: () => `,"timestamp":"${new Date(Date.now()).toISOString()}"`,
+            redact: {
+              paths: redactFields,
+              censor: '**CENSORED**',
+            },
+            transport: isTestEnv
+              ? undefined
+              : isProdEnv
+              ? {
+                  target: 'pino/file',
+                  level: 'error', // log only errors to file
+                  options: {
+                    ...basePinoOptions,
+                    destination: 'logs/error.log',
+                    mkdir: true,
+                    sync: false,
+                  },
+                }
+              : {
+                  targets: [
+                    {
+                      target: 'pino-pretty',
+                      level: 'info', // log only info and above to console
+                      options: {
+                        ...basePinoOptions,
+                        colorize: true,
+                      },
+                    },
+                    {
+                      target: 'pino/file',
+                      level: 'error', // log only errors to file
+                      options: {
+                        ...basePinoOptions,
+                        destination: 'logs/error.log',
+                        mkdir: true,
+                        sync: false,
+                      },
+                    },
+                  ],
                 },
-              },
-            ],
+            level: isTestEnv ? 'silent' : 'info',
           },
-        },
-      }),
+        };
+      },
     }),
   ],
   exports: [LoggerModule],


### PR DESCRIPTION
### Новый функционал

Добавлен пайплайн для [Drone](https://docs.drone.io/), который загружает и запускает последний develop-образ проекта из репозитория GitHub.
Для работы должен быть настроен сервер и раннер Drone. В настоящий момент это сделано на сервере по адресу drone.urup.ru. После успешного процесса деплоя сервис становится доступным по адресу http://airbnb3.stage.urup.ru:8000

### Изменения

- В `docker-compose.yml` - определены тома для постоянного хранения данных MongoDB и Redis
- Файлы логов сервера перенесены из ./app.log в ./logs/*.log
