### PR TITLE
fix: telegram service disabled config var.

### DIFF
--- a/src/lib/telegram/telegram.service.ts
+++ b/src/lib/telegram/telegram.service.ts
@@ -17,7 +17,7 @@ export class TelegramService {
     @Inject(TELEGRAM_MODULE_OPTIONS) private options: TelegramOptions,
     private configService: ConfigService<IConfig, true>,
   ) {
-    this.isServiceDisabled = configService.get('mail.serviceDisabled', { infer: true });
+    this.isServiceDisabled = configService.get('telegram.serviceDisabled', { infer: true });
 
     if (this.isServiceDisabled) {
       return;
@@ -35,6 +35,9 @@ export class TelegramService {
     }
 
     if (!chatId) {
+      this.logger.warn(
+        'Trying to send an message while chat ID id undefined. Check TELEGRAM_CHAT_ID env var.',
+      );
       return;
     }
 


### PR DESCRIPTION
### Исправления

Опция отключения сервиса доставки сообщений через Telegram была основана на неправильной переменной. Исправлено.

### Улучшения

Будет выводиться предупреждении при отправке сообщения в Телеграм в случае если не задан идентификатор чата `TELEGRAM_CHAT_ID`