### PR TITLE
fix(ci): run Drone build by webhook from action

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -24,4 +24,4 @@ trigger:
     - develop
     - ci
   event:
-    - push
+    - custom

--- a/.github/workflows/create-docker-image.yml
+++ b/.github/workflows/create-docker-image.yml
@@ -44,6 +44,10 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Create Drone build for stage
+        run: |
+          curl -X POST ${{ secrets.DRONE_HOST }}/repos/${{ github.repository }}/builds?branch=${{ github.ref_name }}&commit=${{ github.sha }} -H "Authorization: Bearer ${{ secrets.DRONE_TOKEN }}"
   
 
     


### PR DESCRIPTION
Исправление
Билд Drone будет запускаться не по событию пуша в ветку репозитория, я по web-хуку из действия после создания нового docker-образа приложения.